### PR TITLE
Delete duplicated names

### DIFF
--- a/names.txt
+++ b/names.txt
@@ -191,13 +191,11 @@ Chidozie Inya
 Sylvester Eziagor
 Kingsley Sado
 Ikemefuna Adaeze Gift
-Sam Abasifreke
 Nosike Pascal C
 oyeka nonso christopher
 Olawole Jethro
 Desire Oluwarotimi
 Philip Nwachukwu
-Taiwo Stephen Opeyemi
 Nneka Chukwuemeka
 Ikemefuna Adaeze
 Peter Abolude
@@ -278,7 +276,6 @@ Obaloluwa Oladunjoye
 Prince Chimaobi
 Chinecherem Ugwuanyi
 Kingsley Kwesi Salvo
-Chinecherem Ugwuanyi
 Oyinkansola Shoroye
 Chijioke Elijah
 Onyeanuna Prince
@@ -300,7 +297,6 @@ Nnadiukwu Chidiebere Oscar
 Ojima Grace Ohaba
 Oloruntobi Madamori
 Oyediran Paul
-Oloruntobi Madamori
 Afabor Michael Onafome
 Kofoworola Oyinlola Cole
 Olagunju Oluwakolade 


### PR DESCRIPTION
The following names appear twice in the list.

["Chinecherem Ugwuanyi", "Oloruntobi Madamori", "Sam Abasifreke", "Taiwo Stephen Opeyemi"];

This commit removes one of the two entries for each name.

#701 